### PR TITLE
Update packages to solve the install issue related to conda/conda#11931

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-click==6.7
-setuptools==41.0.1
-python_dateutil==2.7.2
-PyYAML==4.2b1
-requests==2.20.0
+click==8.0.0
+python_dateutil==2.8.2
+PyYAML==6.0
+requests==2.27.1
+setuptools==58.0.4

--- a/setup.py
+++ b/setup.py
@@ -22,11 +22,11 @@ setup(
         '': ['*.yaml'],
     },
     install_requires=[
-        'click==6.7',
-        'setuptools==41.0.1',
-        'python_dateutil==2.7.2',
-        'PyYAML==4.2b1',
-        'requests==2.20.0',
+        'click==8.0.0',
+        'python_dateutil==2.8.2',
+        'PyYAML==6.0',
+        'requests==2.27.1',
+        'setuptools==58.0.4',
     ],
     classifiers=[
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
The issue is related to conda/conda#11931.
## Reproduce

### Environment
```
conda      22.11.0
python     3.10.8
pip        22.2.2
```

### Install
```shell
ett@ett-P65-Creator-8RD ~/D/C/N/t/az (master)> conda install pip                                                                                                                  (reproduce) 
Collecting package metadata (current_repodata.json): done
Solving environment: done

## Package Plan ##

  environment location: /home/ett/miniconda3/envs/reproduce

  added / updated specs:
    - pip


The following NEW packages will be INSTALLED:

  _libgcc_mutex      pkgs/main/linux-64::_libgcc_mutex-0.1-main 
  _openmp_mutex      pkgs/main/linux-64::_openmp_mutex-5.1-1_gnu 
  bzip2              pkgs/main/linux-64::bzip2-1.0.8-h7b6447c_0 
  ca-certificates    pkgs/main/linux-64::ca-certificates-2022.10.11-h06a4308_0 
  certifi            pkgs/main/linux-64::certifi-2022.9.24-py310h06a4308_0 
  ld_impl_linux-64   pkgs/main/linux-64::ld_impl_linux-64-2.38-h1181459_1 
  libffi             pkgs/main/linux-64::libffi-3.4.2-h6a678d5_6 
  libgcc-ng          pkgs/main/linux-64::libgcc-ng-11.2.0-h1234567_1 
  libgomp            pkgs/main/linux-64::libgomp-11.2.0-h1234567_1 
  libstdcxx-ng       pkgs/main/linux-64::libstdcxx-ng-11.2.0-h1234567_1 
  libuuid            pkgs/main/linux-64::libuuid-1.41.5-h5eee18b_0 
  ncurses            pkgs/main/linux-64::ncurses-6.3-h5eee18b_3 
  openssl            pkgs/main/linux-64::openssl-1.1.1s-h7f8727e_0 
  pip                pkgs/main/linux-64::pip-22.2.2-py310h06a4308_0 
  python             pkgs/main/linux-64::python-3.10.8-h7a1cb2a_1 
  readline           pkgs/main/linux-64::readline-8.2-h5eee18b_0 
  setuptools         pkgs/main/linux-64::setuptools-65.5.0-py310h06a4308_0 
  sqlite             pkgs/main/linux-64::sqlite-3.40.0-h5082296_0 
  tk                 pkgs/main/linux-64::tk-8.6.12-h1ccaba5_0 
  tzdata             pkgs/main/noarch::tzdata-2022f-h04d1e81_0 
  wheel              pkgs/main/noarch::wheel-0.37.1-pyhd3eb1b0_0 
  xz                 pkgs/main/linux-64::xz-5.2.8-h5eee18b_0 
  zlib               pkgs/main/linux-64::zlib-1.2.13-h5eee18b_0 


Proceed ([y]/n)? y


Downloading and Extracting Packages

Preparing transaction: done
Verifying transaction: done
Executing transaction: done
ett@ett-P65-Creator-8RD ~/D/C/N/t/az (master)> pip install -e .                                                                                                                   (reproduce) 
Obtaining file:///home/ett/Desktop/Course/NSLab/test/az
  Preparing metadata (setup.py) ... done
Collecting click==6.7
  Using cached click-6.7-py2.py3-none-any.whl (71 kB)
Collecting setuptools==41.0.1
  Using cached setuptools-41.0.1-py2.py3-none-any.whl (575 kB)
Collecting python_dateutil==2.7.2
  Using cached python_dateutil-2.7.2-py2.py3-none-any.whl (212 kB)
Collecting PyYAML==4.2b1
  Using cached PyYAML-4.2b1-cp310-cp310-linux_x86_64.whl
Collecting requests==2.20.0
  Using cached requests-2.20.0-py2.py3-none-any.whl (60 kB)
Collecting six>=1.5
  Using cached six-1.16.0-py2.py3-none-any.whl (11 kB)
Collecting idna<2.8,>=2.5
  Using cached idna-2.7-py2.py3-none-any.whl (58 kB)
Collecting urllib3<1.25,>=1.21.1
  Using cached urllib3-1.24.3-py2.py3-none-any.whl (118 kB)
Requirement already satisfied: certifi>=2017.4.17 in /home/ett/miniconda3/envs/reproduce/lib/python3.10/site-packages (from requests==2.20.0->azoo==1.3.0) (2022.9.24)
Collecting chardet<3.1.0,>=3.0.2
  Using cached chardet-3.0.4-py2.py3-none-any.whl (133 kB)
Installing collected packages: idna, click, chardet, urllib3, six, setuptools, PyYAML, requests, python_dateutil, azoo
  Attempting uninstall: setuptools
    Found existing installation: setuptools 65.5.0
    Uninstalling setuptools-65.5.0:
      Successfully uninstalled setuptools-65.5.0
  Running setup.py develop for azoo
    error: subprocess-exited-with-error
    
    × python setup.py develop did not run successfully.
    │ exit code: 1
    ╰─> [21 lines of output]
        Error processing line 1 of /home/ett/miniconda3/envs/reproduce/lib/python3.10/site-packages/distutils-precedence.pth:
        
          Traceback (most recent call last):
            File "/home/ett/miniconda3/envs/reproduce/lib/python3.10/site.py", line 186, in addpackage
              exec(line)
            File "<string>", line 1, in <module>
          ModuleNotFoundError: No module named '_distutils_hack'
        
        Remainder of file ignored
        Traceback (most recent call last):
          File "<string>", line 2, in <module>
          File "<pip-setuptools-caller>", line 14, in <module>
          File "/home/ett/miniconda3/envs/reproduce/lib/python3.10/site-packages/setuptools/__init__.py", line 20, in <module>
            from setuptools.dist import Distribution, Feature
          File "/home/ett/miniconda3/envs/reproduce/lib/python3.10/site-packages/setuptools/dist.py", line 34, in <module>
            from setuptools.depends import Require
          File "/home/ett/miniconda3/envs/reproduce/lib/python3.10/site-packages/setuptools/depends.py", line 7, in <module>
            from .py33compat import Bytecode
          File "/home/ett/miniconda3/envs/reproduce/lib/python3.10/site-packages/setuptools/py33compat.py", line 55, in <module>
            unescape = getattr(html, 'unescape', html_parser.HTMLParser().unescape)
        AttributeError: 'HTMLParser' object has no attribute 'unescape'
        [end of output]
    
    note: This error originates from a subprocess, and is likely not a problem with pip.
```